### PR TITLE
Workaround for vaadin-grid examples crashing on Edge

### DIFF
--- a/src/main/webapp/vaadin-grid.jsp
+++ b/src/main/webapp/vaadin-grid.jsp
@@ -306,7 +306,7 @@
           }
         </style>
         <paper-input id="filter" label="Filter by first name"></paper-input>
-        <vaadin-grid id="sort" selection-mode="multi">
+        <vaadin-grid id="sort">
           <table>
             <colgroup>
               <col name="firstName" sortable/>
@@ -319,6 +319,7 @@
         <script>
           window.addEventListener('WebComponentsReady', function() {
             var grid = document.querySelector('#sort');
+            grid.selectionMode = 'multi';
             var users = [];
 
             getJSON('https://demo.vaadin.com/demo-data/1.0/people', function(json) {


### PR DESCRIPTION
For some weird reason the vaadin-grid examples page is not working on Edge if the `selection-mode` attribute is used.

Sounds really weird and is not reproduced if the example is copied out from the Liferay/portlet environment. This PR moves assigning the property from attribute to JS code. This seems to fix the page.
